### PR TITLE
[Feat] 이메일 회원가입 시 인증 코드 검증 기능 추가

### DIFF
--- a/apps/backend/docker/db-compose.yml
+++ b/apps/backend/docker/db-compose.yml
@@ -8,8 +8,15 @@ services:
       POSTGRES_DB: postgres
     ports:
       - "5432:5432"
+    healthcheck:                                                                                                                                                                                                                    
+      test: ["CMD-SHELL", "pg_isready -U postgres"]                                                                                                                                                                                 
+      interval: 2s                                                                                                                                                                                                                  
+      timeout: 5s                                                                                                                                                                                                                   
+      retries: 10    
     volumes:
-      - postgres_data:/var/lib/postgresql/data
+      - /var/lib/postgresql/data
+      # 개발중엔 볼륨 사용하지 않음
+      # - postgres_data:/var/lib/postgresql/data
 
 volumes:
   postgres_data:

--- a/apps/backend/docker/db-compose.yml
+++ b/apps/backend/docker/db-compose.yml
@@ -14,9 +14,7 @@ services:
       timeout: 5s                                                                                                                                                                                                                   
       retries: 10    
     volumes:
-      - /var/lib/postgresql/data
-      # 개발중엔 볼륨 사용하지 않음
-      # - postgres_data:/var/lib/postgresql/data
+      - postgres_data:/var/lib/postgresql/data
 
 volumes:
   postgres_data:

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -16,6 +16,7 @@
 		"prod": "node dist/main",
 		"lint": "biome check",
 		"format": "biome format --write",
+		"push-db": "prisma db push",
 		"test": "jest",
 		"test:watch": "jest --watch",
 		"test:cov": "jest --coverage",

--- a/apps/backend/src/auth/auth.controller.ts
+++ b/apps/backend/src/auth/auth.controller.ts
@@ -116,7 +116,7 @@ export class AuthController {
 			// 기존 사용자: 토큰과 함께 리다이렉트
 			this.authService.setTokenToCookie(response, result.accessToken);
 			this.authService.setTokenToCookie(response, result.refreshToken, true);
-			return response.redirect(`${frontendUrl}/auth/callback?`);
+			return response.redirect(`${frontendUrl}/`);
 		}
 
 		// 신규 사용자: 가입 완료 페이지로 리다이렉트

--- a/apps/backend/src/auth/auth.controller.ts
+++ b/apps/backend/src/auth/auth.controller.ts
@@ -138,6 +138,9 @@ export class AuthController {
 	})
 	async completeOAuthRegistration(
 		@Body() dto: OAuthCompleteDto,
+		@Req() request: {
+			tempToken: string;
+		},
 		@Res({ passthrough: true }) response: Response,
 	) {
 		// 이메일 인증 확인
@@ -145,7 +148,7 @@ export class AuthController {
 
 		// 가입 완료
 		const tokens = await this.authService.completeOAuthRegistration(
-			dto.tempToken,
+			request.tempToken,
 			dto.username,
 			dto.email,
 		);

--- a/apps/backend/src/auth/auth.controller.ts
+++ b/apps/backend/src/auth/auth.controller.ts
@@ -61,7 +61,6 @@ export class AuthController {
 		@Res({ passthrough: true }) response: Response,
 	) {
 		await this.authService.registerWithEmail(response, dto);
-		await this.emailService.deleteVerification(dto.email);
 	}
 
 	// ===== Google OAuth =====
@@ -150,8 +149,6 @@ export class AuthController {
 			dto.username,
 			dto.email,
 		);
-
-		// 이메일 인증 삭제
 
 		this.authService.setTokenToCookie(response, tokens.accessToken);
 		this.authService.setTokenToCookie(response, tokens.refreshToken, true);

--- a/apps/backend/src/auth/auth.controller.ts
+++ b/apps/backend/src/auth/auth.controller.ts
@@ -61,6 +61,7 @@ export class AuthController {
 		@Res({ passthrough: true }) response: Response,
 	) {
 		await this.authService.registerWithEmail(response, dto);
+		await this.emailService.deleteVerification(dto.email);
 	}
 
 	// ===== Google OAuth =====
@@ -149,6 +150,8 @@ export class AuthController {
 			dto.username,
 			dto.email,
 		);
+
+		// 이메일 인증 삭제
 
 		this.authService.setTokenToCookie(response, tokens.accessToken);
 		this.authService.setTokenToCookie(response, tokens.refreshToken, true);

--- a/apps/backend/src/auth/auth.controller.ts
+++ b/apps/backend/src/auth/auth.controller.ts
@@ -131,6 +131,7 @@ export class AuthController {
 	 * OAuth 가입을 완료합니다.
 	 */
 	@Post('oauth/complete')
+	@UseGuards(TempTokenGuard)
 	@ApiOperation({
 		summary: 'OAuth 가입 완료 API',
 		description: 'OAuth 가입을 완료합니다.',
@@ -174,7 +175,6 @@ export class AuthController {
 	 * 인증 이메일을 발송합니다.
 	 */
 	@Post('email/send-verification')
-	@UseGuards(TempTokenGuard)
 	@ApiOperation({
 		summary: '인증 이메일 발송 API',
 		description: '인증 이메일을 발송합니다.',

--- a/apps/backend/src/auth/auth.service.ts
+++ b/apps/backend/src/auth/auth.service.ts
@@ -326,13 +326,7 @@ export class AuthService {
 			throw new UnauthorizedException('유효하지 않거나 만료된 요청입니다.');
 		}
 
-		// 2. 이메일 인증 확인
-		const isVerified = await this.emailService.isEmailVerified(email);
-		if (!isVerified) {
-			throw new BadRequestException('이메일 인증이 완료되지 않았습니다.');
-		}
-
-		// 3. 사용자 생성
+		// 2. 사용자 생성
 		const userData: Parameters<typeof this.usersService.createUser>[0] = {
 			email,
 			username,
@@ -347,15 +341,15 @@ export class AuthService {
 
 		const newUser = await this.usersService.createUser(userData);
 
-		// 4. pending 레코드 삭제
+		// 3. pending 레코드 삭제
 		await this.prisma.oAuthPendingRegistration.delete({
 			where: { id: pending.id },
 		});
 
-		// 5. 이메일 인증 삭제
+		// 4. 이메일 인증 삭제
 		await this.emailService.deleteVerification(email);
 
-		// 6. JWT 발급
+		// 5. JWT 발급
 		return this.generateToken(newUser);
 	}
 

--- a/apps/backend/src/auth/auth.service.ts
+++ b/apps/backend/src/auth/auth.service.ts
@@ -284,6 +284,12 @@ export class AuthService {
 		};
 	}
 
+	/**
+	 * 임시 토큰으로 OAuth pending 레코드를 조회합니다.
+	 *
+	 * @param tempToken - 임시 토큰
+	 * @returns OAuth pending 레코드
+	 */
 	async getPendingRegistration(tempToken: string) {
 		return await this.prisma.oAuthPendingRegistration.findFirst({
 			where: { tempToken },
@@ -307,8 +313,11 @@ export class AuthService {
 		email: string,
 	): Promise<{ accessToken: string; refreshToken: string }> {
 		// 1. pending 레코드 조회
-		const pending = await this.prisma.oAuthPendingRegistration.findUnique({
+		const pending = await this.prisma.oAuthPendingRegistration.findFirst({
 			where: { tempToken },
+			orderBy: {
+				createdAt: 'desc',
+			},
 		});
 
 		if (!pending || pending.expiresAt < new Date()) {
@@ -341,7 +350,10 @@ export class AuthService {
 			where: { id: pending.id },
 		});
 
-		// 5. JWT 발급
+		// 5. 이메일 인증 삭제
+		await this.emailService.deleteVerification(email);
+
+		// 6. JWT 발급
 		return this.generateToken(newUser);
 	}
 

--- a/apps/backend/src/auth/auth.service.ts
+++ b/apps/backend/src/auth/auth.service.ts
@@ -62,8 +62,9 @@ export class AuthService {
 
 		const hash = await bcrypt.hash(dto.password, HASH_ROUNDS);
 
+		const { verificationCode: _, ...userData } = dto;
 		const newUser = await this.usersService.createUser({
-			...dto,
+			...userData,
 			password: hash,
 		});
 

--- a/apps/backend/src/auth/auth.service.ts
+++ b/apps/backend/src/auth/auth.service.ts
@@ -71,6 +71,8 @@ export class AuthService {
 
 		this.setTokenToCookie(response, tokens.accessToken);
 		this.setTokenToCookie(response, tokens.refreshToken, true);
+
+		this.emailService.deleteVerification(dto.email);
 	}
 
 	/**

--- a/apps/backend/src/auth/auth.service.ts
+++ b/apps/backend/src/auth/auth.service.ts
@@ -18,6 +18,7 @@ import {
 	JWT_REFRESH_TOKEN_EXPIRES_IN,
 	JWT_SECRET,
 } from './consts/auth.const';
+import { RegistrationWithEmailAndPasswordDto } from './dtos/authentication.dto';
 import { JWT_TOKEN_Payload } from './types/jwt.type';
 import type { OAuthCallbackResult, OAuthProfile } from './types/oauth.type';
 
@@ -39,25 +40,30 @@ export class AuthService {
 	 * 이메일로 신규 사용자를 등록하고 토큰을 발급합니다.
 	 * 이메일 인증이 완료되지 않은 경우 예외를 발생시킵니다.
 	 *
-	 * @param user - 등록할 사용자 정보 (username, email, password)
+	 * @param dto - 등록할 사용자 정보 (username, email, password)
 	 * @returns Access Token과 Refresh Token을 포함한 객체
 	 */
 	async registerWithEmail(
 		response: Response,
-		user: Pick<UserModel, 'username' | 'email' | 'password'>,
+		dto: RegistrationWithEmailAndPasswordDto,
 	) {
-		if (!user.password) {
+		if (!dto.password) {
 			throw new BadRequestException('비밀번호가 없습니다.');
 		}
 
-		const hash = await bcrypt.hash(user.password, HASH_ROUNDS);
+		const isVerified = await this.emailService.verifyCode(
+			dto.email,
+			dto.verificationCode,
+		);
 
-		if (!this.emailService.isEmailVerified(user.email)) {
+		if (!isVerified) {
 			throw new BadRequestException('이메일 인증이 완료되지 않았습니다.');
 		}
 
+		const hash = await bcrypt.hash(dto.password, HASH_ROUNDS);
+
 		const newUser = await this.usersService.createUser({
-			...user,
+			...dto,
 			password: hash,
 		});
 

--- a/apps/backend/src/auth/dtos/authentication.dto.ts
+++ b/apps/backend/src/auth/dtos/authentication.dto.ts
@@ -1,6 +1,12 @@
 import { AUTH } from '@interview-lab/shared';
 import { ApiProperty, ApiSchema } from '@nestjs/swagger';
-import { IsEmail, IsString, Matches, MinLength } from 'class-validator';
+import {
+	IsEmail,
+	IsString,
+	Matches,
+	MaxLength,
+	MinLength,
+} from 'class-validator';
 
 @ApiSchema({
 	name: 'EmailAndPasswordDto',
@@ -40,4 +46,13 @@ export class RegistrationWithEmailAndPasswordDto extends EmailAndPasswordDto {
 		message: '이름은 3자 이상이어야 합니다.',
 	})
 	username!: string;
+
+	@IsString()
+	@MinLength(AUTH.CONST.VERIFICATION_CODE_LENGTH)
+	@MaxLength(AUTH.CONST.VERIFICATION_CODE_LENGTH)
+	@ApiProperty({
+		description: '이메일 인증 코드',
+		example: '123456',
+	})
+	verificationCode!: string;
 }

--- a/apps/backend/src/auth/dtos/oauth-complete.dto.ts
+++ b/apps/backend/src/auth/dtos/oauth-complete.dto.ts
@@ -1,7 +1,6 @@
 import { AUTH } from '@interview-lab/shared';
 import { ApiProperty, ApiSchema } from '@nestjs/swagger';
 import {
-	IsDecimal,
 	IsEmail,
 	IsNumberString,
 	IsString,
@@ -17,13 +16,6 @@ import {
 	description: 'OAuth 가입 완료 DTO',
 })
 export class OAuthCompleteDto {
-	@IsString()
-	@ApiProperty({
-		description: '임시 토큰',
-		example: 'uuid-token',
-	})
-	tempToken!: string;
-
 	@IsString()
 	@MinLength(AUTH.CONST.USERNAME_MIN_LENGTH)
 	@MaxLength(20)

--- a/apps/backend/src/auth/dtos/oauth-complete.dto.ts
+++ b/apps/backend/src/auth/dtos/oauth-complete.dto.ts
@@ -1,6 +1,13 @@
 import { AUTH } from '@interview-lab/shared';
 import { ApiProperty, ApiSchema } from '@nestjs/swagger';
-import { IsEmail, IsString, MaxLength, MinLength } from 'class-validator';
+import {
+	IsDecimal,
+	IsEmail,
+	IsNumberString,
+	IsString,
+	MaxLength,
+	MinLength,
+} from 'class-validator';
 
 /**
  * OAuth 가입 완료 요청 DTO
@@ -33,7 +40,7 @@ export class OAuthCompleteDto {
 	})
 	email!: string;
 
-	@IsString()
+	@IsNumberString()
 	@MinLength(AUTH.CONST.VERIFICATION_CODE_LENGTH)
 	@MaxLength(AUTH.CONST.VERIFICATION_CODE_LENGTH)
 	@ApiProperty({

--- a/apps/backend/src/auth/guards/token.guard.ts
+++ b/apps/backend/src/auth/guards/token.guard.ts
@@ -100,6 +100,8 @@ export class AccessTokenGuard extends TokenGuard {
 
 /**
  * 임시 토큰이 존재하는지 확인합니다.
+ *
+ * @description OAuth 가입 완료 API에서 사용됩니다.
  */
 @Injectable()
 export class TempTokenGuard implements CanActivate {

--- a/apps/backend/src/auth/guards/token.guard.ts
+++ b/apps/backend/src/auth/guards/token.guard.ts
@@ -122,6 +122,8 @@ export class TempTokenGuard implements CanActivate {
 			throw new UnauthorizedException('유효하지 않거나 만료된 요청입니다.');
 		}
 
+		request.tempToken = tempToken;
+
 		return true;
 	}
 }

--- a/apps/frontend/src/app/(auth)/(form)/additional-info/page.tsx
+++ b/apps/frontend/src/app/(auth)/(form)/additional-info/page.tsx
@@ -124,7 +124,9 @@ export default function AdditionalInfoPage() {
 						(time || isLoading) && timerStyle,
 					)}
 					onClick={handleSendVerificationCode}
-					disabled={state.email.isError || time > 0 || isLoading}
+					disabled={
+						!state.email.touched || state.email.isError || time > 0 || isLoading
+					}
 				>
 					{sendVerificationCodeText}
 				</Atom.TextButton>

--- a/apps/frontend/src/app/(auth)/(form)/additional-info/page.tsx
+++ b/apps/frontend/src/app/(auth)/(form)/additional-info/page.tsx
@@ -26,9 +26,10 @@ export default function AdditionalInfoPage() {
 		if (isLoading) return;
 
 		setIsLoading(true);
-		await fetch(`${process.env.NEXT_PUBLIC_API_SERVER}/auth/register/email`, {
+		await fetch(`${process.env.NEXT_PUBLIC_API_SERVER}/auth/oauth/complete`, {
 			headers: {
 				'Content-Type': 'application/json',
+				'x-temp-token': searchParams.get('tempToken') ?? '',
 			},
 			method: 'POST',
 			body: JSON.stringify({
@@ -53,7 +54,6 @@ export default function AdditionalInfoPage() {
 			{
 				headers: {
 					'Content-Type': 'application/json',
-					'x-temp-token': searchParams.get('tempToken') ?? '',
 				},
 				method: 'POST',
 				body: JSON.stringify({
@@ -75,9 +75,17 @@ export default function AdditionalInfoPage() {
 			value: searchParams.get('email') || '',
 		});
 		dispatch({
+			type: 'blur',
+			field: 'email',
+		});
+		dispatch({
 			type: 'change',
 			field: 'username',
 			value: searchParams.get('name') || '',
+		});
+		dispatch({
+			type: 'blur',
+			field: 'username',
 		});
 	}, [searchParams, dispatch]);
 

--- a/apps/frontend/src/app/(auth)/(form)/login/page.tsx
+++ b/apps/frontend/src/app/(auth)/(form)/login/page.tsx
@@ -1,24 +1,41 @@
 'use client';
 
 import { Atom, Molecule } from '@interview-lab/ui';
+import { useRouter } from 'next/navigation';
+import { type FormEvent, useState } from 'react';
 import useLoginForm from '@/hooks/useLoginForm';
 import { buttonStyle, formStyle } from './page.css';
 
 export default function LoginPage() {
+	const router = useRouter();
 	const [state, dispatch] = useLoginForm();
+	const [isLoading, setIsLoading] = useState(false);
 
-	const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+	const handleSubmit = async (e: FormEvent<HTMLFormElement>) => {
 		e.preventDefault();
-		fetch(`${process.env.NEXT_PUBLIC_API_SERVER}/auth/login/email`, {
-			headers: {
-				'Content-Type': 'application/json',
+		if (isLoading) return;
+
+		setIsLoading(true);
+		const response = await fetch(
+			`${process.env.NEXT_PUBLIC_API_SERVER}/auth/login/email`,
+			{
+				headers: {
+					'Content-Type': 'application/json',
+					credentials: 'include',
+				},
+				method: 'POST',
+				credentials: 'include',
+				body: JSON.stringify({
+					email: state.email.value,
+					password: state.password.value,
+				}),
 			},
-			method: 'POST',
-			body: JSON.stringify({
-				email: state.email.value,
-				password: state.password.value,
-			}),
-		});
+		);
+
+		if (response.ok) {
+			router.push('/');
+		}
+		setIsLoading(false);
 	};
 
 	const isFormValid = Object.values(state).every(

--- a/apps/frontend/src/app/(auth)/(form)/signup/page.tsx
+++ b/apps/frontend/src/app/(auth)/(form)/signup/page.tsx
@@ -2,6 +2,7 @@
 import { AUTH } from '@interview-lab/shared';
 import { Atom, Molecule } from '@interview-lab/ui';
 import clsx from 'clsx';
+import { useRouter } from 'next/navigation';
 import { type FormEvent, type MouseEvent, useState } from 'react';
 import useSignupForm from '@/hooks/useSignupForm';
 import useTimer from '@/hooks/useTimer';
@@ -15,6 +16,7 @@ import {
 const DEFAULT_PENDING_TIME = 60;
 
 export default function SignupPage() {
+	const router = useRouter();
 	const [state, dispatch] = useSignupForm();
 	const [time, updateTime] = useTimer(0);
 	const [isLoading, setIsLoading] = useState(false);
@@ -24,18 +26,26 @@ export default function SignupPage() {
 		if (isLoading) return;
 
 		setIsLoading(true);
-		await fetch(`${process.env.NEXT_PUBLIC_API_SERVER}/auth/register/email`, {
-			headers: {
-				'Content-Type': 'application/json',
+		const response = await fetch(
+			`${process.env.NEXT_PUBLIC_API_SERVER}/auth/register/email`,
+			{
+				headers: {
+					'Content-Type': 'application/json',
+				},
+				method: 'POST',
+				credentials: 'include',
+				body: JSON.stringify({
+					email: state.email.value,
+					password: state.password.value,
+					username: state.username.value,
+					verificationCode: state.verificationCode.value,
+				}),
 			},
-			method: 'POST',
-			body: JSON.stringify({
-				email: state.email.value,
-				password: state.password.value,
-				username: state.username.value,
-				verificationCode: state.verificationCode.value,
-			}),
-		});
+		);
+
+		if (response.ok) {
+			router.push('/');
+		}
 		setIsLoading(false);
 	};
 
@@ -54,6 +64,7 @@ export default function SignupPage() {
 					'Content-Type': 'application/json',
 				},
 				method: 'POST',
+				credentials: 'include',
 				body: JSON.stringify({
 					email: state.email.value,
 				}),

--- a/apps/frontend/src/app/(auth)/(form)/signup/page.tsx
+++ b/apps/frontend/src/app/(auth)/(form)/signup/page.tsx
@@ -109,7 +109,9 @@ export default function SignupPage() {
 						(time || isLoading) && timerStyle,
 					)}
 					onClick={handleSendVerificationCode}
-					disabled={state.email.isError || time > 0 || isLoading}
+					disabled={
+						!state.email.touched || state.email.isError || time > 0 || isLoading
+					}
 				>
 					{sendVerificationCodeText}
 				</Atom.TextButton>

--- a/apps/frontend/src/app/(auth)/(form)/signup/page.tsx
+++ b/apps/frontend/src/app/(auth)/(form)/signup/page.tsx
@@ -1,15 +1,30 @@
 'use client';
-
+import { AUTH } from '@interview-lab/shared';
 import { Atom, Molecule } from '@interview-lab/ui';
+import clsx from 'clsx';
+import { type FormEvent, type MouseEvent, useState } from 'react';
 import useSignupForm from '@/hooks/useSignupForm';
+import useTimer from '@/hooks/useTimer';
 import { buttonStyle, formStyle } from '../login/page.css';
+import {
+	emailFieldContainerStyle,
+	sendVerificationCodeButton,
+	timerStyle,
+} from './signup.css';
+
+const DEFAULT_PENDING_TIME = 60;
 
 export default function SignupPage() {
 	const [state, dispatch] = useSignupForm();
+	const [time, updateTime] = useTimer(0);
+	const [isLoading, setIsLoading] = useState(false);
 
-	const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+	const handleSubmit = async (e: FormEvent<HTMLFormElement>) => {
 		e.preventDefault();
-		fetch(`${process.env.NEXT_PUBLIC_API_SERVER}/auth/register/email`, {
+		if (isLoading) return;
+
+		setIsLoading(true);
+		await fetch(`${process.env.NEXT_PUBLIC_API_SERVER}/auth/register/email`, {
 			headers: {
 				'Content-Type': 'application/json',
 			},
@@ -18,13 +33,45 @@ export default function SignupPage() {
 				email: state.email.value,
 				password: state.password.value,
 				username: state.username.value,
+				verificationCode: state.verificationCode.value,
 			}),
 		});
+		setIsLoading(false);
+	};
+
+	const handleSendVerificationCode = async (
+		e: MouseEvent<HTMLButtonElement>,
+	) => {
+		e.preventDefault();
+		if (isLoading) return;
+
+		setIsLoading(true);
+		updateTime(DEFAULT_PENDING_TIME);
+		const response = await fetch(
+			`${process.env.NEXT_PUBLIC_API_SERVER}/auth/email/send-verification`,
+			{
+				headers: {
+					'Content-Type': 'application/json',
+				},
+				method: 'POST',
+				body: JSON.stringify({
+					email: state.email.value,
+				}),
+			},
+		);
+		const { remainingTime } = await response.json();
+		if (remainingTime) {
+			updateTime(remainingTime);
+		}
+		setIsLoading(false);
 	};
 
 	const isFormValid = Object.values(state).every(
 		(field) => !field.isError && field.touched,
 	);
+
+	const sendVerificationCodeText =
+		time > 0 ? `${time} S` : isLoading ? '전송 중' : '인증번호 전송';
 
 	return (
 		<form className={formStyle} onSubmit={handleSubmit}>
@@ -41,18 +88,53 @@ export default function SignupPage() {
 				}
 				onBlur={() => dispatch({ type: 'blur', field: 'username' })}
 			/>
+			<div className={emailFieldContainerStyle}>
+				<Molecule.InputWithValidation
+					leftIcon={<Atom.Icon icon="IconMail" />}
+					label="Email"
+					id="email"
+					placeholder="dev@example.com"
+					value={state.email.value}
+					isError={state.email.isError}
+					errorMessage={state.email.errorMessage}
+					onChange={(e) =>
+						dispatch({ type: 'change', field: 'email', value: e.target.value })
+					}
+					onBlur={() => dispatch({ type: 'blur', field: 'email' })}
+				/>
+				<Atom.TextButton
+					type="button"
+					className={clsx(
+						sendVerificationCodeButton,
+						(time || isLoading) && timerStyle,
+					)}
+					onClick={handleSendVerificationCode}
+					disabled={state.email.isError || time > 0 || isLoading}
+				>
+					{sendVerificationCodeText}
+				</Atom.TextButton>
+			</div>
 			<Molecule.InputWithValidation
-				leftIcon={<Atom.Icon icon="IconMail" />}
-				label="Email"
-				id="email"
-				placeholder="dev@example.com"
-				value={state.email.value}
-				isError={state.email.isError}
-				errorMessage={state.email.errorMessage}
+				leftIcon={<Atom.Icon icon="IconKey" />}
+				label="Verification Code"
+				id="verificationCode"
+				placeholder="000000"
+				type="text"
+				inputMode="numeric"
+				pattern={`[0-9]{${AUTH.CONST.VERIFICATION_CODE_LENGTH}}`}
+				maxLength={AUTH.CONST.VERIFICATION_CODE_LENGTH}
+				minLength={AUTH.CONST.VERIFICATION_CODE_LENGTH}
+				value={state.verificationCode.value}
+				isError={state.verificationCode.isError}
+				errorMessage={state.verificationCode.errorMessage}
 				onChange={(e) =>
-					dispatch({ type: 'change', field: 'email', value: e.target.value })
+					dispatch({
+						type: 'change',
+						field: 'verificationCode',
+						value: e.target.value,
+					})
 				}
-				onBlur={() => dispatch({ type: 'blur', field: 'email' })}
+				onBlur={() => dispatch({ type: 'blur', field: 'verificationCode' })}
 			/>
 			<Molecule.InputPassword
 				leftIcon={<Atom.Icon icon="IconLock" />}
@@ -87,7 +169,7 @@ export default function SignupPage() {
 			<Atom.TextButton
 				className={buttonStyle}
 				type="submit"
-				disabled={!isFormValid}
+				disabled={!isFormValid || isLoading}
 			>
 				Sign up
 			</Atom.TextButton>

--- a/apps/frontend/src/app/(auth)/(form)/signup/signup.css.ts
+++ b/apps/frontend/src/app/(auth)/(form)/signup/signup.css.ts
@@ -1,0 +1,19 @@
+import { vars } from '@interview-lab/ui/theme';
+import { style } from '@vanilla-extract/css';
+
+export const emailFieldContainerStyle = style({
+	display: 'flex',
+	gap: vars.spacing['3'],
+});
+
+export const sendVerificationCodeButton = style({
+	backgroundColor: '#192633',
+	color: vars.color.white,
+	height: 52,
+	marginTop: 25,
+});
+
+export const timerStyle = style({
+	backgroundColor: vars.color.grayLight,
+	color: vars.color.gray,
+});

--- a/apps/frontend/src/hooks/useAdditionalInfoForm.ts
+++ b/apps/frontend/src/hooks/useAdditionalInfoForm.ts
@@ -57,7 +57,8 @@ const ERROR_MESSAGE: Record<FieldName, string> = {
 const VALIDATION_RULES = {
 	email: (value: string) => AUTH.CONST.EMAIL_REGEX.test(value),
 	username: (value: string) => value.length >= AUTH.CONST.USERNAME_MIN_LENGTH,
-	verificationCode: (value: string) => value.length === 6,
+	verificationCode: (value: string) =>
+		value.length === AUTH.CONST.VERIFICATION_CODE_LENGTH && /^\d+$/.test(value),
 } satisfies Record<FieldName, (value: string) => boolean>;
 
 function validate(field: FieldName, value: string): boolean {

--- a/apps/frontend/src/hooks/useSignupForm.ts
+++ b/apps/frontend/src/hooks/useSignupForm.ts
@@ -10,7 +10,12 @@ type FieldState = {
 	errorMessage: string;
 };
 
-type FieldName = 'username' | 'email' | 'password' | 'confirmPassword';
+type FieldName =
+	| 'username'
+	| 'email'
+	| 'password'
+	| 'confirmPassword'
+	| 'verificationCode';
 
 type FormState = Record<FieldName, FieldState>;
 
@@ -52,6 +57,12 @@ const INITIAL_STATE: FormState = {
 		isError: false,
 		errorMessage: '',
 	},
+	verificationCode: {
+		value: '',
+		touched: false,
+		isError: false,
+		errorMessage: '',
+	},
 };
 
 const ERROR_MESSAGE: Record<FieldName, string> = {
@@ -60,6 +71,7 @@ const ERROR_MESSAGE: Record<FieldName, string> = {
 	password:
 		'Password include at least one uppercase letter, one lowercase letter',
 	confirmPassword: 'Passwords do not match',
+	verificationCode: `Verification code must be ${AUTH.CONST.VERIFICATION_CODE_LENGTH} digits`,
 };
 
 const VALIDATION_RULES = {
@@ -68,6 +80,8 @@ const VALIDATION_RULES = {
 	password: (value: string) => AUTH.CONST.PASSWORD_REGEX.test(value),
 	confirmPassword: (password: string, confirmPassword: string) =>
 		password === confirmPassword,
+	verificationCode: (value: string) =>
+		value.length === AUTH.CONST.VERIFICATION_CODE_LENGTH && /^\d+$/.test(value),
 } satisfies Record<FieldName, (...args: string[]) => boolean>;
 
 function validate(field: FieldName, value: string, state: FormState): boolean {

--- a/scripts/restart_db
+++ b/scripts/restart_db
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"                              
+
+docker compose -f "$SCRIPT_DIR/../apps/backend/docker/db-compose.yml" down
+
+docker compose -f "$SCRIPT_DIR/../apps/backend/docker/db-compose.yml" up --wait
+
+cd "$SCRIPT_DIR/../apps/backend" && npm run push-db
+
+cd ../..

--- a/scripts/restart_db
+++ b/scripts/restart_db
@@ -2,7 +2,7 @@
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"                              
 
-docker compose -f "$SCRIPT_DIR/../apps/backend/docker/db-compose.yml" down
+docker compose -f "$SCRIPT_DIR/../apps/backend/docker/db-compose.yml" down -v
 
 docker compose -f "$SCRIPT_DIR/../apps/backend/docker/db-compose.yml" up --wait
 

--- a/scripts/start_db
+++ b/scripts/start_db
@@ -2,4 +2,8 @@
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"                                                                                                                                                                                                                               
 
-docker compose -f "$SCRIPT_DIR/../apps/backend/docker/db-compose.yml" up 
+docker compose -f "$SCRIPT_DIR/../apps/backend/docker/db-compose.yml" up --wait
+
+cd "$SCRIPT_DIR/../apps/backend" && npm run push-db
+
+cd ../..


### PR DESCRIPTION
## 개요
회원가입 API에서 이메일 인증 코드를 직접 검증하도록 변경했습니다.
프론트엔드 회원가입 페이지에도 이메일 인증 기능을 추가했습니다.

## 유형
- [x] 새로운 기능 추가
- [x] 버그 수정
- [x] 기타 (개발 환경 개선)

## 변경점

### Backend
- DTO에 verificationCode 필드 추가
- registerWithEmail에서 인증 코드 검증 로직 추가
- 회원가입/OAuth 완료 시 이메일 인증 정보 삭제
- OAuth 로그인 후 홈(/)으로 리다이렉트

### Frontend
- useSignupForm 훅에 verificationCode 필드 추가
- 인증번호 전송 버튼 및 타이머 UI 추가
- 초기 폼 값 설정 시 blur 이벤트로 유효성 검사 트리거

### 개발 환경
- Docker Compose healthcheck 추가
- start_db 스크립트에서 자동 prisma db push

## PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.