### PR TITLE
[Feat] AnswerActiveBar 컴포넌트 추가

### DIFF
--- a/packages/ui/src/components/molecules/AnswerActiveBar/AnswerActiveBar.css.ts
+++ b/packages/ui/src/components/molecules/AnswerActiveBar/AnswerActiveBar.css.ts
@@ -1,0 +1,34 @@
+import { style } from '@vanilla-extract/css';
+import { vars } from '@/styles/theme.css';
+
+export const containerStyle = style({
+	display: 'flex',
+	width: '100%',
+	borderRadius: vars.radius.md,
+	background: vars.color.white,
+	padding: vars.spacing[4],
+	gap: vars.spacing[4],
+	border: `${vars.border.width1} ${vars.color.grayLight}`,
+	boxShadow: vars.shadow.xl,
+});
+
+export const sendButtonStyle = style({
+	flex: 1,
+	background: vars.color.blue,
+	fontFamily: vars.font.pretendard,
+	color: vars.color.white,
+	fontWeight: vars.fontWeight.semibold,
+	fontSize: 18,
+	paddingInline: 14,
+	cursor: 'pointer',
+	':hover': {
+		background: vars.color.blueHover,
+	},
+	boxShadow: `0 10px 15px -3px ${vars.color.blueAlpha30}, 0 4px 6px -4px ${vars.color.blueAlpha30}`,
+});
+
+export const muteButtonStyle = style({
+	':hover': {
+		background: vars.color.grayLight,
+	},
+});

--- a/packages/ui/src/components/molecules/AnswerActiveBar/AnswerActiveBar.css.ts
+++ b/packages/ui/src/components/molecules/AnswerActiveBar/AnswerActiveBar.css.ts
@@ -18,7 +18,7 @@ export const sendButtonStyle = style({
 	fontFamily: vars.font.pretendard,
 	color: vars.color.white,
 	fontWeight: vars.fontWeight.semibold,
-	fontSize: 18,
+	fontSize: vars.fontSize.sizeLg,
 	paddingInline: 14,
 	cursor: 'pointer',
 	':hover': {

--- a/packages/ui/src/components/molecules/AnswerActiveBar/AnswerActiveBar.stories.tsx
+++ b/packages/ui/src/components/molecules/AnswerActiveBar/AnswerActiveBar.stories.tsx
@@ -1,0 +1,29 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import AnswerActiveBar from '.';
+
+const meta: Meta<typeof AnswerActiveBar> = {
+	title: 'Design System/Molecule/AnswerActiveBar',
+	component: AnswerActiveBar,
+	decorators: [
+		(Story) => (
+			<div style={{ width: 672 }}>
+				<Story />
+			</div>
+		),
+	],
+	argTypes: {
+		onSend: { action: 'send' },
+		onMuteToggle: { action: 'muteToggle' },
+	},
+};
+
+export default meta;
+type Story = StoryObj<typeof AnswerActiveBar>;
+
+export const Default: Story = {};
+
+export const Muted: Story = {
+	args: {
+		isMuted: true,
+	},
+};

--- a/packages/ui/src/components/molecules/AnswerActiveBar/index.tsx
+++ b/packages/ui/src/components/molecules/AnswerActiveBar/index.tsx
@@ -1,0 +1,36 @@
+import clsx from 'clsx';
+import { CircleButton, TextButton } from '@/components/atoms';
+import {
+	containerStyle,
+	muteButtonStyle,
+	sendButtonStyle,
+} from './AnswerActiveBar.css';
+
+type AnswerActiveBarProps = {
+	isMuted?: boolean;
+	onSend?: () => void;
+	onMuteToggle?: () => void;
+	className?: string;
+};
+
+const AnswerActiveBar = ({
+	isMuted = false,
+	onSend,
+	onMuteToggle,
+	className,
+}: AnswerActiveBarProps) => {
+	return (
+		<div className={clsx(containerStyle, className)}>
+			<TextButton icon="IconSend" className={sendButtonStyle} onClick={onSend}>
+				Send Answer
+			</TextButton>
+			<CircleButton
+				icon={isMuted ? 'IconMute' : 'IconRecord'}
+				onClick={onMuteToggle}
+				className={muteButtonStyle}
+			/>
+		</div>
+	);
+};
+
+export default AnswerActiveBar;

--- a/packages/ui/src/components/molecules/index.ts
+++ b/packages/ui/src/components/molecules/index.ts
@@ -1,3 +1,4 @@
+export { default as AnswerActiveBar } from './AnswerActiveBar';
 export { default as DashboardCard } from './DashboardCard';
 export { default as Header, navLinkStyle } from './Header';
 export { default as InputPassword } from './InputPassword';

--- a/packages/ui/src/styles/theme.css.ts
+++ b/packages/ui/src/styles/theme.css.ts
@@ -56,6 +56,8 @@ export const vars = createGlobalTheme(':root', {
 		sizeSm: '14px',
 		// Button1 (16px Bold), Subtitle (16px SemiBold)
 		sizeBase: '16px',
+		// SendButton (18px SemiBold)
+		sizeLg: '18px',
 		// Title3 (20px SemiBold)
 		sizeXl: '20px',
 		// Title1 (36px ExtraBold), Title2 (36px Bold)


### PR DESCRIPTION
## 개요
인터뷰 답변 전송 바 컴포넌트 구현

## 유형
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [x] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 변경점
- Send Answer 버튼과 Mute 토글 버튼 포함
- isMuted, onSend, onMuteToggle props 지원

## 스크린샷
<img width="675" height="137" alt="image" src="https://github.com/user-attachments/assets/111f157d-98ff-4909-8d59-6a82ef9e968a" />


## PR Checklist
<!--PR이 다음 요구 사항을 충족하는지 확인하세요.-->
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.
