### PR TITLE
[Feat] UserResponseDto 추가 및 사용자 API 개선

### DIFF
--- a/apps/backend/src/email/email.service.ts
+++ b/apps/backend/src/email/email.service.ts
@@ -76,7 +76,7 @@ export class EmailService {
 	 * @returns 생성된 인증 정보
 	 */
 	async createVerificationInfo(email: string, code: string) {
-		const expiresAt = new Date(Date.now() + 1 * MINUTE);
+		const expiresAt = new Date(Date.now() + 5 * MINUTE);
 
 		return await this.prisma.emailVerification.create({
 			data: {

--- a/apps/backend/src/main.ts
+++ b/apps/backend/src/main.ts
@@ -26,7 +26,7 @@ async function bootstrap() {
 		.setTitle('Interview lab API')
 		.setDescription('인터뷰랩 API 문서')
 		.setVersion('1.0')
-		.addCookieAuth('accessToken', { type: 'http' })
+		.addCookieAuth('accessToken')
 		.build();
 
 	const document = SwaggerModule.createDocument(app, config);

--- a/apps/backend/src/users/decorators/user.decorator.ts
+++ b/apps/backend/src/users/decorators/user.decorator.ts
@@ -3,9 +3,12 @@ import {
 	ExecutionContext,
 	InternalServerErrorException,
 } from '@nestjs/common';
+import { User as UserType } from '@/generated/prisma/client';
 
 export const User = createParamDecorator((_, context: ExecutionContext) => {
-	const { user } = context.switchToHttp().getRequest();
+	const { user }: { user: UserType | null } = context
+		.switchToHttp()
+		.getRequest();
 
 	if (!user) {
 		throw new InternalServerErrorException(

--- a/apps/backend/src/users/dtos/user.dto.ts
+++ b/apps/backend/src/users/dtos/user.dto.ts
@@ -1,0 +1,52 @@
+import { ApiProperty, ApiSchema } from '@nestjs/swagger';
+import { User } from '@/generated/prisma/client';
+
+@ApiSchema({
+	name: 'UserResponseDto',
+	description: '사용자 공개 정보 응답 DTO',
+})
+export class UserResponseDto {
+	@ApiProperty({ description: '사용자 ID', example: 1 })
+	id!: number;
+
+	@ApiProperty({
+		description: '이메일 주소',
+		example: 'user@example.com',
+	})
+	email!: string;
+
+	@ApiProperty({ description: '사용자 닉네임', example: 'BHyeonKim' })
+	username!: string;
+
+	@ApiProperty({
+		description: '프로필 이미지 URL',
+		example: 'https://example.com/profile.jpg',
+		nullable: true,
+	})
+	profileImage!: string | null;
+
+	@ApiProperty({ description: '사용자 레벨', example: 1 })
+	level!: number;
+
+	@ApiProperty({ description: 'Google 연동 여부', example: false })
+	isGoogleLinked!: boolean;
+
+	@ApiProperty({ description: 'GitHub 연동 여부', example: false })
+	isGithubLinked!: boolean;
+
+	@ApiProperty({ description: '가입일' })
+	createdAt!: Date;
+
+	static fromUser(user: User): UserResponseDto {
+		return {
+			id: user.id,
+			email: user.email,
+			username: user.username,
+			profileImage: user.profileImage,
+			level: user.level,
+			isGoogleLinked: !!user.googleId,
+			isGithubLinked: !!user.githubId,
+			createdAt: user.createdAt,
+		};
+	}
+}

--- a/apps/backend/src/users/users.controller.ts
+++ b/apps/backend/src/users/users.controller.ts
@@ -8,11 +8,11 @@ import {
 } from '@nestjs/common';
 import { ApiCookieAuth, ApiOperation, ApiTags } from '@nestjs/swagger';
 import { AccessTokenGuard } from '@/auth/guards/token.guard';
+import type { User as UserType } from '@/generated/prisma/client';
+import MESSAGE from '@/users/consts/message.const';
 import { User } from '@/users/decorators/user.decorator';
 import { UserResponseDto } from '@/users/dtos/user.dto';
 import { UsersService } from '@/users/users.service';
-import MESSAGE from '@/users/consts/message.const';
-import type { User as UserType } from '@/generated/prisma/client';
 
 @Controller('users')
 @ApiTags('사용자')

--- a/apps/backend/src/users/users.controller.ts
+++ b/apps/backend/src/users/users.controller.ts
@@ -12,6 +12,7 @@ import { User } from '@/users/decorators/user.decorator';
 import { UserResponseDto } from '@/users/dtos/user.dto';
 import { UsersService } from '@/users/users.service';
 import MESSAGE from '@/users/consts/message.const';
+import type { User as UserType } from '@/generated/prisma/client';
 
 @Controller('users')
 @ApiTags('사용자')
@@ -30,18 +31,16 @@ export class UsersController {
 
 	@Get('profile')
 	@UseGuards(AccessTokenGuard)
-
 	@ApiOperation({
 		summary: '내 프로필 조회 API',
 		description: '로그인한 사용자의 프로필 정보를 조회합니다.',
 	})
 	@ApiCookieAuth('accessToken')
-	getUserProfile(@User() user) {
+	getUserProfile(@User() user: UserType) {
 		return UserResponseDto.fromUser(user);
 	}
 
 	@Get(':id')
-	@UseGuards(AccessTokenGuard)
 	@ApiOperation({
 		summary: '특정 사용자 조회 API',
 		description: '특정 사용자의 정보를 조회합니다.',

--- a/apps/backend/src/users/users.controller.ts
+++ b/apps/backend/src/users/users.controller.ts
@@ -6,10 +6,12 @@ import {
 	ParseIntPipe,
 	UseGuards,
 } from '@nestjs/common';
-import { ApiOperation, ApiTags } from '@nestjs/swagger';
+import { ApiCookieAuth, ApiOperation, ApiTags } from '@nestjs/swagger';
 import { AccessTokenGuard } from '@/auth/guards/token.guard';
 import { User } from '@/users/decorators/user.decorator';
+import { UserResponseDto } from '@/users/dtos/user.dto';
 import { UsersService } from '@/users/users.service';
+import MESSAGE from '@/users/consts/message.const';
 
 @Controller('users')
 @ApiTags('사용자')
@@ -21,32 +23,38 @@ export class UsersController {
 		summary: '전체 사용자 목록 조회 API',
 		description: '전체 사용자 목록을 조회합니다.',
 	})
-	getUsers() {
-		return this.usersService.getUsersList();
+	async getUsers(): Promise<UserResponseDto[]> {
+		const users = await this.usersService.getUsersList();
+		return users.map(UserResponseDto.fromUser);
 	}
 
 	@Get('profile')
 	@UseGuards(AccessTokenGuard)
+
 	@ApiOperation({
 		summary: '내 프로필 조회 API',
 		description: '로그인한 사용자의 프로필 정보를 조회합니다.',
 	})
+	@ApiCookieAuth('accessToken')
 	getUserProfile(@User() user) {
-		return user;
+		return UserResponseDto.fromUser(user);
 	}
 
 	@Get(':id')
+	@UseGuards(AccessTokenGuard)
 	@ApiOperation({
 		summary: '특정 사용자 조회 API',
 		description: '특정 사용자의 정보를 조회합니다.',
 	})
-	getUserInfo(@Param('id', ParseIntPipe) id: number) {
-		const user = this.usersService.getUserById(id);
+	async getUserInfo(
+		@Param('id', ParseIntPipe) id: number,
+	): Promise<UserResponseDto> {
+		const user = await this.usersService.getUserById(id);
 
 		if (!user) {
-			throw new NotFoundException('User not found');
+			throw new NotFoundException(MESSAGE.ERROR_USER_NOT_FOUND);
 		}
 
-		return user;
+		return UserResponseDto.fromUser(user);
 	}
 }

--- a/apps/backend/src/users/users.service.ts
+++ b/apps/backend/src/users/users.service.ts
@@ -1,5 +1,5 @@
 import { BadRequestException, Injectable } from '@nestjs/common';
-import { Prisma } from '@/generated/prisma/client';
+import { Prisma, User } from '@/generated/prisma/client';
 import { PrismaService } from '@/prisma/prisma.service';
 
 @Injectable()
@@ -24,21 +24,14 @@ export class UsersService {
 		});
 	}
 
-	async getUsersList() {
-		return this.prisma.user.findMany({
-			omit: {
-				password: true,
-			},
-		});
+	async getUsersList(): Promise<User[]> {
+		return this.prisma.user.findMany();
 	}
 
-	async getUserById(userId: number) {
+	async getUserById(userId: number): Promise<User | null> {
 		return this.prisma.user.findUnique({
 			where: {
 				id: userId,
-			},
-			omit: {
-				password: true,
 			},
 		});
 	}


### PR DESCRIPTION
## 개요
사용자 API의 응답 형식을 개선하고 민감 정보(password 등)가 노출되지 않도록 UserResponseDto를 추가했습니다.
Swagger 문서에서 쿠키 인증을 올바르게 표시하도록 설정을 수정했습니다.

## 유형
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제
## 변경점

### 1. UserResponseDto 추가 (`apps/backend/src/users/dtos/user.dto.ts`)
- 사용자 공개 정보만 포함하는 응답 DTO 클래스 생성
- `fromUser()` 정적 메서드로 User 엔티티를 DTO로 변환
- Swagger API 문서용 데코레이터 적용 (@ApiProperty, @ApiSchema)
- 포함 필드: id, email, username, profileImage, level, isGoogleLinked, isGithubLinked, createdAt

### 2. Users Controller 개선 (`apps/backend/src/users/users.controller.ts`)
- 모든 사용자 조회 API에 UserResponseDto 적용
- `GET /users/profile`에 @ApiCookieAuth 데코레이터 추가
- `GET /users/:id`에 AccessTokenGuard 추가
- 에러 메시지 상수화 (MESSAGE.ERROR_USER_NOT_FOUND)

### 3. Users Service 리팩토링 (`apps/backend/src/users/users.service.ts`)
- 반환 타입 명시 (`Promise<User[]>`, `Promise<User | null>`)
- Prisma omit 옵션 제거 (DTO 레이어에서 필터링)

### 4. User 데코레이터 타입 추가 (`apps/backend/src/users/decorators/user.decorator.ts`)
- request.user에 타입 지정 (`UserType | null`)

### 5. Swagger 쿠키 인증 설정 수정 (`apps/backend/src/main.ts`)
- `addCookieAuth('accessToken', { type: 'http' })` → `addCookieAuth('accessToken')`
- 쿠키 인증은 apiKey 타입이므로 잘못된 옵션 제거

## 스크린샷

## PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.